### PR TITLE
Don't use Java 22 to build plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>22</java.version>
+        <java.version>21</java.version>
         <revision>7.0.0</revision>
         <maven.test.skip>true</maven.test.skip>
     </properties>


### PR DESCRIPTION
Since Minecraft’s minimum required Java version is 21, most servers will also use Java 21. Therefore, the plugin should also use Java 21.
This fixes the issue when the plugin is loaded on a Java 21 server. (com/hm/achievement/AdvancedAchievements has been compiled by a more recent version of the Java Runtime (class file version 66.0), this version of the Java Runtime only recognizes class file versions up to 65.0)